### PR TITLE
fix(fuse): guard tail warmup when disk cache is disabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -1446,7 +1446,7 @@ func (h *MkvHandle) Read(fuseCtx context.Context, dest []byte, off int64) (fuse.
 	// V265: Tail warmup — serve last 16MB from SSD for MKV Cues/seek index.
 	// V560: Discovery-Only Tail Warmup. isTailProbe=true means off is in tail area AND
 	// ConfirmedAt.IsZero(). Post-confirmation tail reads fall through to the pump for fresh data.
-	if isTailProbe {
+	if isTailProbe && diskWarmup != nil {
 		// V560-Fix: Tail reads must NOT steer the pump. Restore lastOff to prevOff so
 		// V284 doesn't jump the pump to the cold end-of-file on the next tick.
 		atomic.StoreInt64(&h.lastOff, prevOff)


### PR DESCRIPTION
catch a panic, it also leaks fuse mounts which was a little annoying to catch.

```
gostream  | panic: runtime error: invalid memory address or nil pointer dereference
gostream  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1108485]
gostream  |
gostream  | goroutine 12 [running]:
gostream  | main.(*DiskWarmupCache).tailPath(0x0, {0xc000c956a2, 0x28}, 0x412cc6?)                                                                                                     gostream  |     /src/disk_warmup.go:284 +0x45
gostream  | main.(*DiskWarmupCache).ReadTail(0x0, {0xc000c956a2?, 0x133d0a0?}, 0xc001225b60?, {0xc007254000, 0x11000, 0x11000}, 0x2c1a45000, 0x41df31?)
gostream  |     /src/disk_warmup.go:444 +0x7b
gostream  | main.(*MkvHandle).Read(0xc000674a90, {0x17a5548, 0xc0072521c8}, {0xc007254000, 0x11000, 0x11000}, 0x2c1a45000)
gostream  |     /src/main.go:1453 +0xcb7
gostream  | github.com/hanwen/go-fuse/v2/fs.(*rawBridge).Read(0x41ce54?, 0xc000470a80, 0xc000357ad8, {0xc007254000, 0x11000, 0x11000})
gostream  |     /go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.9.0/fs/bridge.go:860 +0x169
gostream  | github.com/hanwen/go-fuse/v2/fuse.doRead(0xc0003b23c0?, 0xc0003578c8)
gostream  |     /go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.9.0/fuse/opcode.go:368 +0x4a
```