### PR TITLE
Containerize health monitor and harden FUSE shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ docker run -d \
   -v /mnt/gostream-mkv-real:/mnt/gostream-mkv-real \
   -v /mnt/gostream-mkv-virtual:/mnt/gostream-mkv-virtual \
   -p 8090:8090 \
+  -p 8095:8095 \
   -p 8096:8096 \
   gostream
 ```

--- a/config.go
+++ b/config.go
@@ -71,11 +71,11 @@ type Config struct {
 	MaxCacheEntries         int `json:"max_cache_entries"`
 
 	// --- Connectivity ---
-	GoStormBaseURL string `json:"gostorm_url"`
-	ProxyListenPort   int    `json:"proxy_listen_port"`
-	MetricsPort       int    `json:"metrics_port"`
-	BlockListURL      string `json:"blocklist_url"`
-	AIURL             string `json:"ai_url"` // V1.4.5: AI Optimizer sidecar URL
+	GoStormBaseURL  string `json:"gostorm_url"`
+	ProxyListenPort int    `json:"proxy_listen_port"`
+	MetricsPort     int    `json:"metrics_port"`
+	BlockListURL    string `json:"blocklist_url"`
+	AIURL           string `json:"ai_url"` // V1.4.5: AI Optimizer sidecar URL
 
 	// --- FUSE Paths ---
 	// Fallback when CLI args are omitted. CLI args always take precedence.
@@ -109,8 +109,8 @@ type Config struct {
 	ReadBufferSize          int           `json:"-"`
 
 	// --- Disk Warmup ---
-	DiskWarmupQuotaGB  int64 `json:"disk_warmup_quota_gb"`   // Total SSD quota for warmup cache (default: 32)
-	WarmupHeadSizeMB   int64 `json:"warmup_head_size_mb"`    // Per-file head warmup cap in MB (default: 64)
+	DiskWarmupQuotaGB int64 `json:"disk_warmup_quota_gb"` // Total SSD quota for warmup cache (default: 32)
+	WarmupHeadSizeMB  int64 `json:"warmup_head_size_mb"`  // Per-file head warmup cap in MB (default: 64)
 
 	// --- NAT-PMP (V228) ---
 	NatPMP NatPMPConfig `json:"natpmp"`
@@ -168,16 +168,16 @@ func LoadConfig() Config {
 		WarmupHeadSizeMB:        64,
 
 		Scheduler: SchedulerConfig{
-			Enabled:    false, // off by default — won't break installs using cron
-			MoviesSync: DailyJobConfig{Enabled: true, DaysOfWeek: []int{1, 4}, Hour: 3, Minute: 0},
-			TVSync:     DailyJobConfig{Enabled: true, DaysOfWeek: []int{3, 5}, Hour: 4, Minute: 0},
+			Enabled:       false, // off by default — won't break installs using cron
+			MoviesSync:    DailyJobConfig{Enabled: true, DaysOfWeek: []int{1, 4}, Hour: 3, Minute: 0},
+			TVSync:        DailyJobConfig{Enabled: true, DaysOfWeek: []int{3, 5}, Hour: 4, Minute: 0},
 			WatchlistSync: WatchlistSyncConfig{Enabled: true, IntervalHours: 1},
 		},
 
-		GoStormBaseURL: "http://127.0.0.1:8090",
-		AIURL:          "http://127.0.0.1:8085", // Default Pi internal AI port (V1.4.5)
-		ProxyListenPort:   8080,
-		MetricsPort:       8096,
+		GoStormBaseURL:  "http://127.0.0.1:8090",
+		AIURL:           "http://127.0.0.1:8085", // Default Pi internal AI port (V1.4.5)
+		ProxyListenPort: 8080,
+		MetricsPort:     8096,
 
 		// Legacy Fixed Defaults
 		DefaultFileSize:         30 * 1024 * 1024 * 1024,
@@ -282,6 +282,12 @@ func (c *Config) applyEnvOverrides() {
 	if v := os.Getenv("MKV_PROXY_AI_URL"); v != "" {
 		c.AIURL = v
 	}
+	if v := firstEnv("GOSTREAM_PLEX_URL", "PLEX_URL"); v != "" {
+		c.Plex.URL = v
+	}
+	if v := firstEnv("GOSTREAM_PLEX_TOKEN", "PLEX_TOKEN"); v != "" {
+		c.Plex.Token = v
+	}
 	if v := os.Getenv("MKV_PROXY_LOG_LEVEL"); v != "" {
 		c.LogLevel = v
 	}
@@ -295,6 +301,15 @@ func (c *Config) applyEnvOverrides() {
 			c.GID = uint32(n)
 		}
 	}
+}
+
+func firstEnv(keys ...string) string {
+	for _, key := range keys {
+		if value := os.Getenv(key); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (c *Config) finalize() {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,19 +20,36 @@ RUN apt-get update \
       ca-certificates \
       fuse3 \
       iptables \
+      python3 \
+      python3-venv \
       tini \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
+COPY requirements.txt /tmp/requirements.txt
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/venv/bin/pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm -f /tmp/requirements.txt
+
 COPY --from=build /out/gostream /usr/local/bin/gostream
 COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY scripts /app/scripts
 
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
+ENV PATH=/opt/venv/bin:$PATH
 ENV MKV_PROXY_CONFIG_PATH=/config.json
+ENV GOSTREAM_ROOT_PATH=/usr/local
 ENV GOSTREAM_SOURCE_PATH=/mnt/gostream-mkv-real
 ENV GOSTREAM_MOUNT_PATH=/mnt/gostream-mkv-virtual
+ENV GOSTREAM_STATE_DIR=/usr/local/STATE
+ENV GOSTREAM_LOG_DIR=/usr/local/logs
+ENV HEALTH_MONITOR_PORT=8095
+ENV GOSTREAM_HEALTH_MONITOR_ENABLED=1
+
+EXPOSE 8090 8095 8096
 
 # tini is used as PID 1 to forward signals (e.g. SIGTERM on docker stop) to
 # gostream and reap zombie processes. Without it, the shell entrypoint script

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,26 +2,21 @@
 set -eu
 
 CONFIG_PATH="${MKV_PROXY_CONFIG_PATH:-/config.json}"
+ROOT_PATH="${GOSTREAM_ROOT_PATH:-/usr/local}"
 SOURCE_PATH="${GOSTREAM_SOURCE_PATH:-/mnt/gostream-mkv-real}"
 MOUNT_PATH="${GOSTREAM_MOUNT_PATH:-/mnt/gostream-mkv-virtual}"
+STATE_DIR="${GOSTREAM_STATE_DIR:-$ROOT_PATH/STATE}"
+LOG_DIR="${GOSTREAM_LOG_DIR:-$ROOT_PATH/logs}"
+HEALTH_MONITOR_ENABLED="${GOSTREAM_HEALTH_MONITOR_ENABLED:-1}"
+HEALTH_MONITOR_PORT="${HEALTH_MONITOR_PORT:-8095}"
 
-mkdir -p "$SOURCE_PATH" "$MOUNT_PATH"
+mkdir -p "$SOURCE_PATH" "$MOUNT_PATH" "$ROOT_PATH" "$STATE_DIR" "$LOG_DIR"
 
-# Clean up any stale FUSE mount left by a previous crash. Without this,
-# fs.Mount() will fail with "transport endpoint is not connected".
-# -u unmounts, -z defers cleanup until the mountpoint is no longer busy.
-#
-# IMPORTANT: only unmount if the existing mount is actually FUSE. Docker's
-# rshared bind mount for this path may already be present when the container
-# starts. Unmounting it would destroy the peer group link needed for
-# rshared propagation back to the host, causing an empty virtual directory.
+# Manual recovery mode: do not unmount at startup. The stale-FUSE cleanup can
+# break bind propagation back to the host Plex path. We keep the shutdown
+# cleanup below, but leave the startup mount topology intact.
 if mountpoint -q "$MOUNT_PATH" 2>/dev/null; then
-  if grep -q " $MOUNT_PATH fuse" /proc/mounts 2>/dev/null; then
-    echo "Stale FUSE mount detected at $MOUNT_PATH, cleaning up..." >&2
-    fusermount3 -uz "$MOUNT_PATH" || true
-  else
-    echo "Non-FUSE mountpoint at $MOUNT_PATH (Docker bind), leaving intact." >&2
-  fi
+  echo "Existing mountpoint at $MOUNT_PATH detected; leaving it intact on startup." >&2
 fi
 
 if [ ! -f "$CONFIG_PATH" ]; then
@@ -29,24 +24,50 @@ if [ ! -f "$CONFIG_PATH" ]; then
   exit 1
 fi
 
-# Run gostream in the background rather than exec'ing it, so we can trap
-# SIGTERM (forwarded by tini) and explicitly unmount FUSE before exit.
-# Without this, the kernel leaves the mount in a dead-but-present state and
-# the host-side rshared bind mount becomes "transport endpoint not connected"
-# on every container restart.
-/usr/local/bin/gostream "$SOURCE_PATH" "$MOUNT_PATH" &
-GOSTREAM_PID=$!
+health_pid=""
+gostream_pid=""
 
-cleanup() {
-  echo "[entrypoint] Shutdown signal received, unmounting FUSE at $MOUNT_PATH..." >&2
-  kill -TERM "$GOSTREAM_PID" 2>/dev/null || true
-  wait "$GOSTREAM_PID" 2>/dev/null || true
+shutdown() {
+  trap - INT TERM EXIT
+
+  if [ -n "$health_pid" ] && kill -0 "$health_pid" 2>/dev/null; then
+    kill "$health_pid" 2>/dev/null || true
+  fi
+
+  if [ -n "$gostream_pid" ] && kill -0 "$gostream_pid" 2>/dev/null; then
+    kill -TERM "$gostream_pid" 2>/dev/null || true
+  fi
+
+  wait ${health_pid:+"$health_pid"} ${gostream_pid:+"$gostream_pid"} 2>/dev/null || true
   fusermount3 -uz "$MOUNT_PATH" 2>/dev/null || true
 }
-trap cleanup TERM INT
 
-# Wait for gostream; also unmount if it exits on its own (crash, restart, etc.)
-wait "$GOSTREAM_PID"
-EXIT_CODE=$?
-fusermount3 -uz "$MOUNT_PATH" 2>/dev/null || true
-exit "$EXIT_CODE"
+trap shutdown INT TERM EXIT
+
+if [ "$HEALTH_MONITOR_ENABLED" = "1" ]; then
+  echo "Starting health monitor on port $HEALTH_MONITOR_PORT" >&2
+  python3 /app/scripts/health-monitor.py &
+  health_pid="$!"
+fi
+
+echo "Starting gostream" >&2
+/usr/local/bin/gostream --path "$ROOT_PATH" "$SOURCE_PATH" "$MOUNT_PATH" &
+gostream_pid="$!"
+
+while :; do
+  if [ -n "$health_pid" ] && ! kill -0 "$health_pid" 2>/dev/null; then
+    wait "$health_pid" || true
+    echo "health-monitor exited; stopping container" >&2
+    exit 1
+  fi
+
+  if ! kill -0 "$gostream_pid" 2>/dev/null; then
+    wait "$gostream_pid"
+    exit_code=$?
+    fusermount3 -uz "$MOUNT_PATH" 2>/dev/null || true
+    echo "gostream exited; stopping container" >&2
+    exit "$exit_code"
+  fi
+
+  sleep 1
+done

--- a/scripts/gostorm-sync-complete.py
+++ b/scripts/gostorm-sync-complete.py
@@ -13,6 +13,7 @@ import re
 import sys
 import time
 import requests
+import urllib3
 from prowlarr_client import ProwlarrClient
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
@@ -40,12 +41,30 @@ def _load_gostream_config() -> dict:
     # GoStream/config.json → GoStream dir is the base dir for STATE
     # logs stay at parent level (shared with gostream binary and health-monitor)
     config_dir = os.path.dirname(os.path.abspath(config_path))
-    cfg.setdefault('_state_dir', os.path.join(config_dir, 'STATE'))
-    cfg.setdefault('_log_dir', os.path.join(config_dir, 'logs'))
+    cfg['_state_dir'] = os.environ.get('GOSTREAM_STATE_DIR', os.path.join(config_dir, 'STATE'))
+    cfg['_log_dir'] = os.environ.get('GOSTREAM_LOG_DIR', os.path.join(config_dir, 'logs'))
+    plex_cfg = cfg.setdefault('plex', {})
+    plex_cfg['url'] = os.environ.get('GOSTREAM_PLEX_URL') or os.environ.get('PLEX_URL') or plex_cfg.get('url', '')
+    plex_cfg['token'] = os.environ.get('GOSTREAM_PLEX_TOKEN') or os.environ.get('PLEX_TOKEN') or plex_cfg.get('token', '')
     return cfg
 
 
 _cfg = _load_gostream_config()
+
+
+def _env_truthy(value: object) -> bool:
+    return str(value).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def _normalize_plex_url(url: str) -> str:
+    if PLEX_INSECURE_TLS and url.startswith('http://') and ':32400' in url:
+        return 'https://' + url[len('http://'):]
+    return url
+
+
+PLEX_INSECURE_TLS = _env_truthy(os.environ.get('GOSTREAM_PLEX_INSECURE_TLS') or os.environ.get('PLEX_INSECURE_TLS'))
+if PLEX_INSECURE_TLS:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class GoStormSync:
@@ -2421,13 +2440,13 @@ class GoStormSync:
 
     def notify_plex(self, section_id: int):
         """Send a refresh command to Plex for a specific library section."""
-        PLEX_URL = _cfg.get('plex', {}).get('url', 'http://127.0.0.1:32400')
-        PLEX_TOKEN = _cfg.get('plex', {}).get('token', '')
+        plex_url = _normalize_plex_url(_cfg.get('plex', {}).get('url', 'http://127.0.0.1:32400'))
+        plex_token = _cfg.get('plex', {}).get('token', '')
 
         try:
-            url = f"{PLEX_URL}/library/sections/{section_id}/refresh?X-Plex-Token={PLEX_TOKEN}"
+            url = f"{plex_url}/library/sections/{section_id}/refresh?X-Plex-Token={plex_token}"
             self.log("INFO", f"🚀 Notifying Plex to refresh library section {section_id}...")
-            resp = requests.get(url, timeout=10)
+            resp = requests.get(url, timeout=10, verify=not PLEX_INSECURE_TLS)
             if resp.status_code in (200, 201):
                 self.log_success(f"Plex refresh triggered successfully for section {section_id}")
             else:

--- a/scripts/gostorm-tv-sync.py
+++ b/scripts/gostorm-tv-sync.py
@@ -26,6 +26,7 @@ import signal
 import sys
 import time
 import requests
+import urllib3
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Set, NamedTuple, Any
@@ -43,12 +44,30 @@ def _load_gostream_config() -> dict:
     except Exception:
         cfg = {}
     config_dir = os.path.dirname(os.path.abspath(config_path))
-    cfg.setdefault('_state_dir', os.path.join(config_dir, 'STATE'))
-    cfg.setdefault('_log_dir', os.path.join(config_dir, 'logs'))
+    cfg['_state_dir'] = os.environ.get('GOSTREAM_STATE_DIR', os.path.join(config_dir, 'STATE'))
+    cfg['_log_dir'] = os.environ.get('GOSTREAM_LOG_DIR', os.path.join(config_dir, 'logs'))
+    plex_cfg = cfg.setdefault('plex', {})
+    plex_cfg['url'] = os.environ.get('GOSTREAM_PLEX_URL') or os.environ.get('PLEX_URL') or plex_cfg.get('url', '')
+    plex_cfg['token'] = os.environ.get('GOSTREAM_PLEX_TOKEN') or os.environ.get('PLEX_TOKEN') or plex_cfg.get('token', '')
     return cfg
 
 
 _cfg = _load_gostream_config()
+
+
+def _env_truthy(value: object) -> bool:
+    return str(value).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def _normalize_plex_url(url: str) -> str:
+    if PLEX_INSECURE_TLS and url.startswith('http://') and ':32400' in url:
+        return 'https://' + url[len('http://'):]
+    return url
+
+
+PLEX_INSECURE_TLS = _env_truthy(os.environ.get('GOSTREAM_PLEX_INSECURE_TLS') or os.environ.get('PLEX_INSECURE_TLS'))
+if PLEX_INSECURE_TLS:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # Global shutdown flag for graceful termination
 _shutdown_requested = False
@@ -420,13 +439,13 @@ class GoStormTV:
 
     def notify_plex(self, section_id: int):
         """Send a refresh command to Plex for a specific library section."""
-        PLEX_URL = _cfg.get('plex', {}).get('url', 'http://127.0.0.1:32400')
-        PLEX_TOKEN = _cfg.get('plex', {}).get('token', '')
+        plex_url = _normalize_plex_url(_cfg.get('plex', {}).get('url', 'http://127.0.0.1:32400'))
+        plex_token = _cfg.get('plex', {}).get('token', '')
 
         try:
-            url = f"{PLEX_URL}/library/sections/{section_id}/refresh?X-Plex-Token={PLEX_TOKEN}"
+            url = f"{plex_url}/library/sections/{section_id}/refresh?X-Plex-Token={plex_token}"
             self.log("INFO", f"🚀 Notifying Plex to refresh library section {section_id}...")
-            resp = requests.get(url, timeout=10)
+            resp = requests.get(url, timeout=10, verify=not PLEX_INSECURE_TLS)
             if resp.status_code in (200, 201):
                 self.log("INFO", f"Plex refresh triggered successfully for section {section_id}")
             else:
@@ -1664,4 +1683,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/scripts/health-monitor.py
+++ b/scripts/health-monitor.py
@@ -26,6 +26,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import psutil
 import requests
+import urllib3
 from fastapi import FastAPI, Query, Request, File, Form
 from fastapi.responses import HTMLResponse, JSONResponse
 
@@ -42,20 +43,44 @@ def _load_gostream_config() -> dict:
     except Exception:
         cfg = {}
     config_dir = os.path.dirname(os.path.abspath(config_path))
-    cfg.setdefault('_state_dir', os.path.join(config_dir, 'STATE'))
-    cfg.setdefault('_log_dir', os.path.join(config_dir, 'logs'))
+    cfg['_state_dir'] = os.environ.get('GOSTREAM_STATE_DIR', os.path.join(config_dir, 'STATE'))
+    cfg['_log_dir'] = os.environ.get('GOSTREAM_LOG_DIR', os.path.join(config_dir, 'logs'))
+    plex_cfg = cfg.setdefault('plex', {})
+    plex_cfg['url'] = os.environ.get('GOSTREAM_PLEX_URL') or os.environ.get('PLEX_URL') or plex_cfg.get('url', '')
+    plex_cfg['token'] = os.environ.get('GOSTREAM_PLEX_TOKEN') or os.environ.get('PLEX_TOKEN') or plex_cfg.get('token', '')
     return cfg
 
 
 _cfg = _load_gostream_config()
 _scripts_dir = os.path.dirname(os.path.abspath(__file__))
 
+
+def _env_truthy(value: object) -> bool:
+    return str(value).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def _normalize_plex_url(url: str, insecure_tls: bool) -> str:
+    if insecure_tls and url.startswith('http://') and ':32400' in url:
+        return 'https://' + url[len('http://'):]
+    return url
+
+
 # Configuration
 GOSTORM_URL = _cfg.get('gostorm_url', 'http://127.0.0.1:8090')
 PRELOAD_SIZE_MB = 128  # MB to preload
 FUSE_METRICS_URL = f"http://127.0.0.1:{_cfg.get('metrics_port', 8096)}/metrics"
-PLEX_URL     = _cfg.get('plex', {}).get('url', 'http://127.0.0.1:32400')
-PLEX_TOKEN   = _cfg.get('plex', {}).get('token', '')
+PLEX_URL = _cfg.get('plex', {}).get('url', 'http://127.0.0.1:32400')
+PLEX_TOKEN = _cfg.get('plex', {}).get('token', '')
+PLEX_INSECURE_TLS = _env_truthy(os.environ.get('GOSTREAM_PLEX_INSECURE_TLS') or os.environ.get('PLEX_INSECURE_TLS'))
+PLEX_URL = _normalize_plex_url(PLEX_URL, PLEX_INSECURE_TLS)
+if PLEX_INSECURE_TLS:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+def plex_get(url: str, **kwargs):
+    kwargs.setdefault('verify', not PLEX_INSECURE_TLS)
+    return requests.get(url, **kwargs)
+
 FUSE_MOUNT = _cfg.get('fuse_mount_path', '/mnt/torrserver-go')
 MOVIES_DIR = os.path.join(_cfg.get('physical_source_path', '/mnt/torrserver'), 'movies')
 TV_DIR = os.path.join(_cfg.get('physical_source_path', '/mnt/torrserver'), 'tv')
@@ -81,7 +106,7 @@ RESTART_COOLDOWN = 30  # seconds between restarts
 SPEED_HISTORY_SIZE = 180  # 15 minutes of data at 5s intervals
 ACTIVE_STICKY_SECONDS = 120  # keep torrent "active" for 15s after speed drops
 
-PORT = 8095
+PORT = int(os.getenv("HEALTH_MONITOR_PORT", "8095"))
 
 # Logging setup
 logging.basicConfig(
@@ -259,7 +284,7 @@ def get_plex_session_info() -> Dict[str, Dict[str, Any]]:
 
     try:
         url = f"{PLEX_URL}/status/sessions?X-Plex-Token={PLEX_TOKEN}"
-        response = requests.get(url, timeout=10)
+        response = plex_get(url, timeout=10)
         if response.status_code != 200:
             return plex_audio_cache
 
@@ -407,7 +432,7 @@ def search_plex_by_filename(filename: str) -> Optional[Dict[str, Any]]:
     """Search Plex library for a specific filename to get metadata (V238: TV Support)."""
     try:
         url = f"{PLEX_URL}/library/sections/all/search?filename={filename}&X-Plex-Token={PLEX_TOKEN}"
-        response = requests.get(url, timeout=5)
+        response = plex_get(url, timeout=5)
         if response.status_code == 200:
             import xml.etree.ElementTree as ET
             root = ET.fromstring(response.text)
@@ -458,7 +483,7 @@ def search_plex_by_filename(filename: str) -> Optional[Dict[str, Any]]:
     try:
         # V238: Removed type=1 to allow searching both movies and episodes
         url = f"{PLEX_URL}/library/sections/all/search?filename={filename}&X-Plex-Token={PLEX_TOKEN}"
-        response = requests.get(url, timeout=5)
+        response = plex_get(url, timeout=5)
         if response.status_code == 200:
             import xml.etree.ElementTree as ET
             root = ET.fromstring(response.text)
@@ -1000,7 +1025,7 @@ def check_natpmp() -> None:
 def check_plex() -> None:
     """Check Plex server status."""
     try:
-        response = requests.get(f"{PLEX_URL}/identity", timeout=5)
+        response = plex_get(f"{PLEX_URL}/identity", timeout=5)
         if response.status_code == 200:
             # Parse XML to extract version from MediaContainer
             version_match = re.search(r'MediaContainer.*?version="([^"]+)"', response.text)

--- a/scripts/plex-watchlist-sync.py
+++ b/scripts/plex-watchlist-sync.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional, Tuple
 from urllib.parse import quote
 
 import requests
+import urllib3
 from prowlarr_client import ProwlarrClient
 
 
@@ -37,16 +38,34 @@ def _load_gostream_config() -> dict:
     except Exception:
         cfg = {}
     config_dir = os.path.dirname(os.path.abspath(config_path))
-    cfg.setdefault('_state_dir', os.path.join(config_dir, 'STATE'))
-    cfg.setdefault('_log_dir', os.path.join(config_dir, 'logs'))
+    cfg['_state_dir'] = os.environ.get('GOSTREAM_STATE_DIR', os.path.join(config_dir, 'STATE'))
+    cfg['_log_dir'] = os.environ.get('GOSTREAM_LOG_DIR', os.path.join(config_dir, 'logs'))
+    plex_cfg = cfg.setdefault('plex', {})
+    plex_cfg['url'] = os.environ.get('GOSTREAM_PLEX_URL') or os.environ.get('PLEX_URL') or plex_cfg.get('url', '')
+    plex_cfg['token'] = os.environ.get('GOSTREAM_PLEX_TOKEN') or os.environ.get('PLEX_TOKEN') or plex_cfg.get('token', '')
     return cfg
 
 
 _cfg = _load_gostream_config()
 
+
+def _env_truthy(value: object) -> bool:
+    return str(value).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
+def _normalize_plex_url(url: str) -> str:
+    if PLEX_INSECURE_TLS and url.startswith('http://') and ':32400' in url:
+        return 'https://' + url[len('http://'):]
+    return url
+
+
 # ── Configuration ─────────────────────────────────────────────────────────────
-PLEX_TOKEN   = _cfg.get('plex', {}).get('token', '')
-PLEX_URL     = _cfg.get('plex', {}).get('url', 'http://127.0.0.1:32400')
+PLEX_TOKEN = _cfg.get('plex', {}).get('token', '')
+PLEX_URL = _cfg.get('plex', {}).get('url', 'http://127.0.0.1:32400')
+PLEX_INSECURE_TLS = _env_truthy(os.environ.get('GOSTREAM_PLEX_INSECURE_TLS') or os.environ.get('PLEX_INSECURE_TLS'))
+PLEX_URL = _normalize_plex_url(PLEX_URL)
+if PLEX_INSECURE_TLS:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 TORRSERVER   = _cfg.get('gostorm_url', 'http://127.0.0.1:8090')
 MOVIES_DIR   = os.path.join(_cfg.get('physical_source_path', '/mnt/torrserver'), 'movies')
 TMDB_API_KEY = _cfg.get('tmdb_api_key', '')
@@ -569,7 +588,7 @@ def create_mkv(
 def notify_plex() -> None:
     url = f"{PLEX_URL}/library/sections/{SECTION_ID}/refresh?X-Plex-Token={PLEX_TOKEN}"
     try:
-        r = session.get(url, timeout=10)
+        r = session.get(url, timeout=10, verify=not PLEX_INSECURE_TLS)
         if r.status_code in (200, 201):
             log.info(f"Plex refresh triggered (section {SECTION_ID})")
         else:


### PR DESCRIPTION
make the health monitor available in the docker container. I had to add some environment variables b/c calling plex on the same host is different than calling from within a container. Things look healthy to me.

Fuse unmount is still broken on docker restarts. I'll open a separate PR when I figure out how to make that work. I may have to just add plex to my docker compose setup.

<img width="1035" height="712" alt="image" src="https://github.com/user-attachments/assets/1ee99705-2282-4ce8-b3ba-a7aa2ba036ea" />
